### PR TITLE
Add OAuth authentication, CRUD operations, and Docker deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PCO_CLIENT_ID=your_pco_oauth_client_id
+PCO_CLIENT_SECRET=your_pco_oauth_client_secret
+BASE_URL=http://your-nas-ip:8000
+JWT_SIGNING_KEY=generate-a-random-secret-here

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,7 @@ ENV/
 .idea/
 .vscode/
 *.swp
-*.swo 
+*.swo
+
+# Docker
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY services.py .
+
+EXPOSE 8000
+
+CMD ["python", "services.py"]

--- a/README.md
+++ b/README.md
@@ -1,73 +1,85 @@
-# Planning Center Online API and MCP Server Integration  
+# Planning Center Online MCP Server
 
-This project integrates the Planning Center Online (PCO) API with an MCP server to enable seamless interaction with a Large Language Model (LLM). The goal is to allow users to ask questions and retrieve data from Planning Center in a conversational manner.  
+An MCP server that integrates with the Planning Center Online (PCO) API, enabling LLMs to query and manage PCO data through natural language. Runs as a shared HTTP server with per-user OAuth authentication.
 
-## Features  
-- **PCO API Integration**: Connects to Planning Center Online to access and manage data.  
-- **FASTMCP Server**: Acts as a middleware to handle requests and responses between the LLM and PCO API.  
-- **LLM Query Support**: Enables natural language queries to fetch and manipulate data from Planning Center.  
+## Features
 
-## Use Cases  
-- Retrieve information about services in Planning Center.  
-- Automate workflows by querying and updating data using natural language.  
-- Provide insights and analytics through conversational queries.  
+- **OAuth Authentication**: Users sign in with their own PCO account — no shared service account
+- **Full CRUD Operations**: Create, read, update, and delete service types, plans, plan items, plan times, and team members
+- **Schedule Management**: View, accept, and decline schedule assignments
+- **Song & Tag Management**: Search, create, and tag songs; manage arrangements and keys
+- **Docker Deployment**: Single-command deployment for NAS or local network hosting
 
-## Getting Started  
+## Available Tools
 
-### Prerequisites  
-- Access to the [Planning Center API](https://developer.planningcenteronline.com/).  
-- Python environment 
-- MCP Client (i.e. Claude Desktop)
-- API keys for authentication.  
+| Category | Operations |
+|---|---|
+| **Service Types** | get, create, update, delete |
+| **Plans** | get, create, update, delete |
+| **Plan Times** | get, create, update, delete |
+| **Plan Items** | get, create, update, delete, reorder |
+| **Team Members** | get, assign, update, remove |
+| **Schedules** | get, accept, decline |
+| **Songs** | get, find, create |
+| **Arrangements** | get all, get specific, get keys |
+| **Tags** | assign to song, find songs by tags |
 
-### Installation  
-1. Clone this repository:  
-    ```bash  
-    git clone https://github.com/your-repo/pco-mcp-integration.git  
-    ```  
-2. Install dependencies:  
-    ```bash  
-    uv pip install -r requirements.txt 
-    ```  
-3. Configure environment variables:  
-    - `PCO_SECRET_KEY`: Your Planning Center API key.  
-    - `PCO_APPLICATION_ID`: URL of the MCP server.  
+## Getting Started
 
-4. Test the server:  
-    ```bash  
-    fastmcp dev services.py
-    ```  
+### Prerequisites
 
-## Usage  
-1. Send a natural language query to the MCP server.  
-2. The server processes the query and interacts with the PCO API.  
-3. Receive a structured response or perform the requested action.  
+- A [Planning Center Online](https://www.planningcenter.com/) account with API access
+- A registered PCO OAuth application at https://api.planningcenteronline.com/oauth/applications
+  - Set the callback URL to `http://your-server:8000/auth/callback`
+  - Request scopes: `services`, `people`
+- Docker (for deployment) or Python 3.12+
 
-Add MCP server config
-``` json
-{
-  "mcpServers": {
-    "pco-services": {
-      "command": "/path/to/fastmcp",
-      "args": ["run", "/path/to/services.py"],
-      "env": {
-        "PCO_APPLICATION_ID": "PCO_CLIENT_ID",
-        "PCO_SECRET_KEY": "PCO_CLIENT_SECRET_KEY"
-      }
-    }
-}
+### Configuration
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```
+PCO_CLIENT_ID=your_pco_oauth_client_id
+PCO_CLIENT_SECRET=your_pco_oauth_client_secret
+BASE_URL=http://your-server-ip:8000
+JWT_SIGNING_KEY=generate-a-random-secret-here
 ```
 
-## Future Work
-It is intended to continue work on other areas of planning center.
+### Running with Docker
 
-## Contributing  
-Contributions are welcome! Please submit a pull request or open an issue for any suggestions or improvements.  
+```bash
+docker compose up --build
+```
 
-## License  
-This project is licensed under the [MIT License](LICENSE).  
+The server starts on port 8000.
 
-## Resources  
-- [Planning Center API Documentation](https://developer.planningcenteronline.com/)  
-- [FastMCP](https://github.com/jlowin/fastmcp)  
+### Running without Docker
+
+```bash
+pip install -r requirements.txt
+python services.py
+```
+
+### Connecting an MCP Client
+
+Point your MCP client (Claude Desktop, Cursor, etc.) at the server's HTTP endpoint:
+
+```
+http://your-server-ip:8000/mcp/
+```
+
+On first connection, the OAuth flow will redirect you to PCO to sign in and authorize access.
+
+## Contributing
+
+Contributions are welcome! Please submit a pull request or open an issue for any suggestions or improvements.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
+## Resources
+
+- [Planning Center API Documentation](https://developer.planningcenteronline.com/)
+- [FastMCP](https://github.com/jlowin/fastmcp)
 - [pypco](https://github.com/billdeitrick/pypco)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  pco-mcp:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastmcp
 pypco
-python-dotenv 
+python-dotenv
+httpx

--- a/services.py
+++ b/services.py
@@ -1,124 +1,720 @@
-from fastmcp import FastMCP
-from pypco import PCO  # Import the PCO client
+import asyncio
 import os
+
+import httpx
 from dotenv import load_dotenv
+from fastmcp import FastMCP
+from fastmcp.server.auth import OAuthProxy, AccessToken, TokenVerifier
+from fastmcp.server.dependencies import Depends
+from pypco import PCO
 
 # Load environment variables from .env file
 load_dotenv()
 
-mcp = FastMCP("PCO Services MCP Server")
 
-# Initialize the PCO client with credentials from environment variables
-pco = PCO(
-    application_id=os.getenv("PCO_APPLICATION_ID"),
-    secret=os.getenv("PCO_SECRET_KEY")
+# =============================================================================
+# OAuth Authentication
+# =============================================================================
+
+class PCOTokenVerifier(TokenVerifier):
+    """Validates PCO OAuth tokens by calling the PCO API."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    "https://api.planningcenteronline.com/people/v2/me",
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=10,
+                )
+                if resp.status_code != 200:
+                    return None
+
+                data = resp.json()["data"]
+                attrs = data["attributes"]
+
+                return AccessToken(
+                    token=token,
+                    client_id="pco",
+                    scopes=["services", "people"],
+                    claims={
+                        "sub": data["id"],
+                        "name": f"{attrs.get('first_name', '')} {attrs.get('last_name', '')}".strip(),
+                        "email": attrs.get("primary_email_address"),
+                        "pco_access_token": token,
+                    },
+                )
+        except Exception:
+            return None
+
+
+auth = OAuthProxy(
+    upstream_authorization_endpoint="https://api.planningcenteronline.com/oauth/authorize",
+    upstream_token_endpoint="https://api.planningcenteronline.com/oauth/token",
+    upstream_client_id=os.environ["PCO_CLIENT_ID"],
+    upstream_client_secret=os.environ["PCO_CLIENT_SECRET"],
+    token_verifier=PCOTokenVerifier(),
+    base_url=os.environ.get("BASE_URL", "http://localhost:8000"),
+    extra_authorize_params={"scope": "services people"},
+    jwt_signing_key=os.environ.get("JWT_SIGNING_KEY"),
 )
 
+mcp = FastMCP("PCO Services MCP Server", auth=auth)
+
+
+# =============================================================================
+# Per-User PCO Client
+# =============================================================================
+
+async def get_pco(token: AccessToken) -> PCO:
+    """Create a per-user PCO client from the authenticated user's upstream token."""
+    upstream_token = token.claims.get("pco_access_token")
+    if not upstream_token:
+        raise ValueError("No PCO access token available")
+    return PCO(token=upstream_token)
+
+
+def _build_patch_body(resource_type: str, **kwargs) -> dict:
+    """Build a JSON:API PATCH body with only non-None attributes."""
+    attributes = {k: v for k, v in kwargs.items() if v is not None}
+    return {
+        "data": {
+            "type": resource_type,
+            "attributes": attributes
+        }
+    }
+
+
+# =============================================================================
+# Service Type Operations
+# =============================================================================
+
 @mcp.tool()
-def get_service_types() -> list:
+async def get_service_types(pco: PCO = Depends(get_pco)) -> list:
     """
     Fetch a list of service types from the Planning Center Online API.
     """
-    # Using the direct get method as shown in the documentation
-    response = pco.get('/services/v2/service_types')
-    # return [service_type['attributes'] for service_type in response['data']]
+    response = await asyncio.to_thread(pco.get, '/services/v2/service_types')
     return response['data']
 
 @mcp.tool()
-def get_plans(service_type_id: str) -> list:
+async def create_service_type(name: str, frequency: str = None, sequence: int = None, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Create a new service type in Planning Center Online.
+
+    Args:
+        name (str): The name of the service type (e.g., "Sunday Morning").
+        frequency (str, optional): How often this service occurs (e.g., "every 1 week").
+        sequence (int, optional): The order in which this service type appears.
+
+    Returns:
+        dict: The created service type data.
+    """
+    attributes = {"name": name}
+    if frequency is not None:
+        attributes["frequency"] = frequency
+    if sequence is not None:
+        attributes["sequence"] = sequence
+
+    body = pco.template("ServiceType", attributes)
+    response = await asyncio.to_thread(pco.post, "/services/v2/service_types", body)
+    return response["data"]
+
+@mcp.tool()
+async def update_service_type(service_type_id: str, name: str = None, frequency: str = None, sequence: int = None, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Update an existing service type in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type to update.
+        name (str, optional): The new name for the service type.
+        frequency (str, optional): The new frequency for the service type.
+        sequence (int, optional): The new sequence number for the service type.
+
+    Returns:
+        dict: The updated service type data.
+    """
+    body = _build_patch_body("ServiceType", name=name, frequency=frequency, sequence=sequence)
+    response = await asyncio.to_thread(pco.patch, f"/services/v2/service_types/{service_type_id}", body)
+    return response["data"]
+
+@mcp.tool()
+async def delete_service_type(service_type_id: str, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Delete a service type from Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type to delete.
+
+    Returns:
+        dict: A confirmation message.
+    """
+    await asyncio.to_thread(pco.delete, f"/services/v2/service_types/{service_type_id}")
+    return {"success": True, "message": f"Service type {service_type_id} deleted successfully."}
+
+
+# =============================================================================
+# Plan Operations
+# =============================================================================
+
+@mcp.tool()
+async def get_plans(service_type_id: str, pco: PCO = Depends(get_pco)) -> list:
     """
     Fetch a list of plans for a specific service type.
-    
+
     Args:
         service_type_id (str): The ID of the service type.
     """
-    # Using the direct get method as shown in the documentation
-    response = pco.get(f'/services/v2/service_types/{service_type_id}/plans?order=-updated_at')
+    response = await asyncio.to_thread(pco.get, f'/services/v2/service_types/{service_type_id}/plans?order=-updated_at')
     return response['data']
 
 @mcp.tool()
-def get_plan_items(plan_id: str) -> list:
+async def create_plan(service_type_id: str, title: str = None, public: bool = None, series_title: str = None, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Create a new plan for a service type in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type to create the plan under.
+        title (str, optional): The title of the plan.
+        public (bool, optional): Whether the plan is publicly visible.
+        series_title (str, optional): The series title for the plan.
+
+    Returns:
+        dict: The created plan data.
+    """
+    attributes = {}
+    if title is not None:
+        attributes["title"] = title
+    if public is not None:
+        attributes["public"] = public
+    if series_title is not None:
+        attributes["series_title"] = series_title
+
+    body = pco.template("Plan", attributes)
+    response = await asyncio.to_thread(pco.post, f"/services/v2/service_types/{service_type_id}/plans", body)
+    return response["data"]
+
+@mcp.tool()
+async def update_plan(service_type_id: str, plan_id: str, title: str = None, public: bool = None, series_title: str = None, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Update an existing plan in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type the plan belongs to.
+        plan_id (str): The ID of the plan to update.
+        title (str, optional): The new title for the plan.
+        public (bool, optional): Whether the plan should be publicly visible.
+        series_title (str, optional): The new series title for the plan.
+
+    Returns:
+        dict: The updated plan data.
+    """
+    body = _build_patch_body("Plan", title=title, public=public, series_title=series_title)
+    response = await asyncio.to_thread(pco.patch, f"/services/v2/service_types/{service_type_id}/plans/{plan_id}", body)
+    return response["data"]
+
+@mcp.tool()
+async def delete_plan(service_type_id: str, plan_id: str, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Delete a plan from Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type the plan belongs to.
+        plan_id (str): The ID of the plan to delete.
+
+    Returns:
+        dict: A confirmation message.
+    """
+    await asyncio.to_thread(pco.delete, f"/services/v2/service_types/{service_type_id}/plans/{plan_id}")
+    return {"success": True, "message": f"Plan {plan_id} deleted successfully."}
+
+
+# =============================================================================
+# Plan Time Operations
+# =============================================================================
+
+@mcp.tool()
+async def get_plan_times(service_type_id: str, plan_id: str, pco: PCO = Depends(get_pco)) -> list:
+    """
+    Fetch a list of times for a specific plan in Planning Center Online.
+
+    Plan times represent scheduled times for a plan such as rehearsals or services.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+
+    Returns:
+        list: A list of plan time data.
+    """
+    response = await asyncio.to_thread(pco.get, f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/plan_times")
+    return response["data"]
+
+@mcp.tool()
+async def create_plan_time(service_type_id: str, plan_id: str, starts_at: str, ends_at: str, time_type: str = None, name: str = None, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Create a new plan time for a plan in Planning Center Online.
+
+    Plan times represent scheduled times for a plan such as rehearsals or services.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        starts_at (str): The start time in ISO 8601 format (e.g., "2025-03-01T09:00:00Z").
+        ends_at (str): The end time in ISO 8601 format (e.g., "2025-03-01T11:00:00Z").
+        time_type (str, optional): The type of time - "rehearsal", "service", or "other".
+        name (str, optional): A name for this time (e.g., "Morning Rehearsal").
+
+    Returns:
+        dict: The created plan time data.
+    """
+    attributes = {"starts_at": starts_at, "ends_at": ends_at}
+    if time_type is not None:
+        attributes["time_type"] = time_type
+    if name is not None:
+        attributes["name"] = name
+
+    body = pco.template("PlanTime", attributes)
+    response = await asyncio.to_thread(
+        pco.post,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/plan_times",
+        body
+    )
+    return response["data"]
+
+@mcp.tool()
+async def update_plan_time(service_type_id: str, plan_id: str, plan_time_id: str, starts_at: str = None, ends_at: str = None, time_type: str = None, name: str = None, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Update an existing plan time in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        plan_time_id (str): The ID of the plan time to update.
+        starts_at (str, optional): The new start time in ISO 8601 format.
+        ends_at (str, optional): The new end time in ISO 8601 format.
+        time_type (str, optional): The new type of time - "rehearsal", "service", or "other".
+        name (str, optional): The new name for this time.
+
+    Returns:
+        dict: The updated plan time data.
+    """
+    body = _build_patch_body("PlanTime", starts_at=starts_at, ends_at=ends_at, time_type=time_type, name=name)
+    response = await asyncio.to_thread(
+        pco.patch,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/plan_times/{plan_time_id}",
+        body
+    )
+    return response["data"]
+
+@mcp.tool()
+async def delete_plan_time(service_type_id: str, plan_id: str, plan_time_id: str, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Delete a plan time from a plan in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        plan_time_id (str): The ID of the plan time to delete.
+
+    Returns:
+        dict: A confirmation message.
+    """
+    await asyncio.to_thread(
+        pco.delete,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/plan_times/{plan_time_id}"
+    )
+    return {"success": True, "message": f"Plan time {plan_time_id} deleted successfully."}
+
+
+# =============================================================================
+# Plan Item Operations
+# =============================================================================
+
+@mcp.tool()
+async def get_plan_items(plan_id: str, pco: PCO = Depends(get_pco)) -> list:
     """
     Fetch a list of items for a specific plan.
-    
+
     Args:
         plan_id (str): The ID of the plan.
     """
-    # Using the direct get method as shown in the documentation
-    response = pco.get(f'/services/v2/plans/{plan_id}/items')
+    response = await asyncio.to_thread(pco.get, f'/services/v2/plans/{plan_id}/items')
     return response['data']
 
 @mcp.tool()
-def get_plan_team_members(plan_id: str) -> list:
+async def create_plan_item(
+    service_type_id: str,
+    plan_id: str,
+    title: str,
+    item_type: str,
+    length: int = None,
+    service_position: str = None,
+    description: str = None,
+    song_id: str = None,
+    arrangement_id: str = None,
+    key_id: str = None,
+    pco: PCO = Depends(get_pco),
+) -> dict:
+    """
+    Create a new item in a plan in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        title (str): The title of the item.
+        item_type (str): The type of item - "song", "header", "media", or "item".
+        length (int, optional): The length of the item in seconds.
+        service_position (str, optional): Position in service - "pre" or "post" (omit for during).
+        description (str, optional): A description for the item.
+        song_id (str, optional): The ID of a song to associate (for song items).
+        arrangement_id (str, optional): The ID of a specific arrangement to use.
+        key_id (str, optional): The ID of a specific key to use.
+
+    Returns:
+        dict: The created item data.
+    """
+    attributes = {"title": title, "item_type": item_type}
+    if length is not None:
+        attributes["length"] = length
+    if service_position is not None:
+        attributes["service_position"] = service_position
+    if description is not None:
+        attributes["description"] = description
+    if song_id is not None:
+        attributes["song_id"] = song_id
+    if arrangement_id is not None:
+        attributes["arrangement_id"] = arrangement_id
+    if key_id is not None:
+        attributes["key_id"] = key_id
+
+    body = pco.template("Item", attributes)
+    response = await asyncio.to_thread(
+        pco.post,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/items",
+        body
+    )
+    return response["data"]
+
+@mcp.tool()
+async def update_plan_item(
+    service_type_id: str,
+    plan_id: str,
+    item_id: str,
+    title: str = None,
+    length: int = None,
+    service_position: str = None,
+    description: str = None,
+    sequence: int = None,
+    pco: PCO = Depends(get_pco),
+) -> dict:
+    """
+    Update an existing item in a plan in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        item_id (str): The ID of the item to update.
+        title (str, optional): The new title for the item.
+        length (int, optional): The new length in seconds.
+        service_position (str, optional): New position - "pre" or "post" (omit for during).
+        description (str, optional): The new description.
+        sequence (int, optional): The new sequence number for ordering.
+
+    Returns:
+        dict: The updated item data.
+    """
+    body = _build_patch_body(
+        "Item",
+        title=title,
+        length=length,
+        service_position=service_position,
+        description=description,
+        sequence=sequence
+    )
+    response = await asyncio.to_thread(
+        pco.patch,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/items/{item_id}",
+        body
+    )
+    return response["data"]
+
+@mcp.tool()
+async def delete_plan_item(service_type_id: str, plan_id: str, item_id: str, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Delete an item from a plan in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        item_id (str): The ID of the item to delete.
+
+    Returns:
+        dict: A confirmation message.
+    """
+    await asyncio.to_thread(
+        pco.delete,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/items/{item_id}"
+    )
+    return {"success": True, "message": f"Plan item {item_id} deleted successfully."}
+
+@mcp.tool()
+async def reorder_plan_items(service_type_id: str, plan_id: str, item_ids: list[str], pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Reorder items within a plan in Planning Center Online.
+
+    The items will be arranged in the order specified by the item_ids list.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        item_ids (list[str]): An ordered list of item IDs representing the desired order.
+
+    Returns:
+        dict: A confirmation message.
+    """
+    body = {
+        "data": {
+            "type": "ItemReorder",
+            "attributes": {
+                "sequence": item_ids
+            }
+        }
+    }
+    await asyncio.to_thread(
+        pco.post,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/item_reorder",
+        body
+    )
+    return {"success": True, "message": "Plan items reordered successfully."}
+
+
+# =============================================================================
+# Team Member Operations
+# =============================================================================
+
+@mcp.tool()
+async def get_plan_team_members(plan_id: str, pco: PCO = Depends(get_pco)) -> list:
     """
     Fetch a list of team members for a specific plan.
-    
+
     Args:
         plan_id (str): The ID of the plan.
     """
-    # Using the direct get method as shown in the documentation
-    response = pco.get(f'/services/v2/plans/{plan_id}/team_members')
+    response = await asyncio.to_thread(pco.get, f'/services/v2/plans/{plan_id}/team_members')
     return response['data']
 
-# @mcp.tool()
-# def get_plan_team_member_assignments(plan_id: str, team_member_id: str) -> list:
-#     """
-#     Fetch a list of assignments for a specific team member in a plan.
-    
-#     Args:
-#         plan_id (str): The ID of the plan.
-#         team_member_id (str): The ID of the team member.
-#     """
-#     # Using the direct get method as shown in the documentation
-#     response = pco.get(f'/services/v2/plans/{plan_id}/team_members/{team_member_id}/assignments')
-#     return response['data']
+@mcp.tool()
+async def assign_team_member(
+    service_type_id: str,
+    plan_id: str,
+    person_id: str,
+    team_position_name: str = None,
+    status: str = None,
+    prepare_notification: bool = None,
+    pco: PCO = Depends(get_pco),
+) -> dict:
+    """
+    Assign a person as a team member to a plan in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        person_id (str): The ID of the person to assign.
+        team_position_name (str, optional): The team position name (e.g., "Vocals", "Sound").
+        status (str, optional): The status - "C" (confirmed), "U" (unconfirmed), or "D" (declined).
+        prepare_notification (bool, optional): Whether to send a notification to the person.
+
+    Returns:
+        dict: The created team member assignment data.
+    """
+    attributes = {}
+    if team_position_name is not None:
+        attributes["team_position_name"] = team_position_name
+    if status is not None:
+        attributes["status"] = status
+    if prepare_notification is not None:
+        attributes["prepare_notification"] = prepare_notification
+
+    body = {
+        "data": {
+            "type": "PlanPerson",
+            "attributes": attributes,
+            "relationships": {
+                "person": {
+                    "data": {"type": "Person", "id": person_id}
+                }
+            }
+        }
+    }
+
+    response = await asyncio.to_thread(
+        pco.post,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/team_members",
+        body
+    )
+    return response["data"]
 
 @mcp.tool()
-def get_songs() -> list:
+async def update_team_member(
+    service_type_id: str,
+    plan_id: str,
+    team_member_id: str,
+    status: str = None,
+    notes: str = None,
+    team_position_name: str = None,
+    pco: PCO = Depends(get_pco),
+) -> dict:
+    """
+    Update an existing team member assignment on a plan in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        team_member_id (str): The ID of the team member assignment to update.
+        status (str, optional): The new status - "C" (confirmed), "U" (unconfirmed), or "D" (declined).
+        notes (str, optional): Notes for the team member.
+        team_position_name (str, optional): The new team position name.
+
+    Returns:
+        dict: The updated team member data.
+    """
+    body = _build_patch_body(
+        "PlanPerson",
+        status=status,
+        notes=notes,
+        team_position_name=team_position_name
+    )
+    response = await asyncio.to_thread(
+        pco.patch,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/team_members/{team_member_id}",
+        body
+    )
+    return response["data"]
+
+@mcp.tool()
+async def remove_team_member(service_type_id: str, plan_id: str, team_member_id: str, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Remove a team member from a plan in Planning Center Online.
+
+    Args:
+        service_type_id (str): The ID of the service type.
+        plan_id (str): The ID of the plan.
+        team_member_id (str): The ID of the team member assignment to remove.
+
+    Returns:
+        dict: A confirmation message.
+    """
+    await asyncio.to_thread(
+        pco.delete,
+        f"/services/v2/service_types/{service_type_id}/plans/{plan_id}/team_members/{team_member_id}"
+    )
+    return {"success": True, "message": f"Team member {team_member_id} removed successfully."}
+
+
+# =============================================================================
+# Schedule Operations
+# =============================================================================
+
+@mcp.tool()
+async def get_person_schedules(person_id: str, pco: PCO = Depends(get_pco)) -> list:
+    """
+    Fetch a list of schedules for a specific person in Planning Center Online.
+
+    Schedules represent a person's upcoming service assignments.
+
+    Args:
+        person_id (str): The ID of the person.
+
+    Returns:
+        list: A list of schedule data for the person.
+    """
+    response = await asyncio.to_thread(pco.get, f"/services/v2/people/{person_id}/schedules")
+    return response["data"]
+
+@mcp.tool()
+async def accept_schedule(person_id: str, schedule_id: str, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Accept a schedule assignment for a person in Planning Center Online.
+
+    Args:
+        person_id (str): The ID of the person.
+        schedule_id (str): The ID of the schedule to accept.
+
+    Returns:
+        dict: A confirmation message.
+    """
+    await asyncio.to_thread(
+        pco.post,
+        f"/services/v2/people/{person_id}/schedules/{schedule_id}/accept",
+        {}
+    )
+    return {"success": True, "message": f"Schedule {schedule_id} accepted successfully."}
+
+@mcp.tool()
+async def decline_schedule(person_id: str, schedule_id: str, reason: str = None, pco: PCO = Depends(get_pco)) -> dict:
+    """
+    Decline a schedule assignment for a person in Planning Center Online.
+
+    Args:
+        person_id (str): The ID of the person.
+        schedule_id (str): The ID of the schedule to decline.
+        reason (str, optional): The reason for declining the schedule.
+
+    Returns:
+        dict: A confirmation message.
+    """
+    body = {}
+    if reason is not None:
+        body = {"data": {"attributes": {"reason": reason}}}
+
+    await asyncio.to_thread(
+        pco.post,
+        f"/services/v2/people/{person_id}/schedules/{schedule_id}/decline",
+        body
+    )
+    return {"success": True, "message": f"Schedule {schedule_id} declined successfully."}
+
+
+# =============================================================================
+# Song Operations
+# =============================================================================
+
+@mcp.tool()
+async def get_songs(pco: PCO = Depends(get_pco)) -> list:
     """
     Fetch a list of songs from the Planning Center Online API.
     """
-    # Using the direct get method as shown in the documentation
-    response = pco.get('/services/v2/songs?per_page=200&where[hidden]=false')
+    response = await asyncio.to_thread(pco.get, '/services/v2/songs?per_page=200&where[hidden]=false')
     return response['data']
 
 @mcp.tool()
-def get_all_arrangements_for_song(song_id: str) -> list:
+async def get_song(song_id: str, pco: PCO = Depends(get_pco)) -> dict:
     """
-    Get a list of all the arrangements for a particular song from the Planning Center Online API.
+    Fetch details for a specific song.
 
-    Args: 
-        song_id (str): The ID for the song. 
+    Args:
+        song_id (str): The ID of the song.
     """
-    response = pco.get(f'/services/v2/songs/{song_id}/arrangements')
+    response = await asyncio.to_thread(pco.get, f'/services/v2/songs/{song_id}')
     return response['data']
 
 @mcp.tool()
-def get_arrangement_for_song(song_id: str, arrangement_id: str) -> list:
+async def find_song_by_title(title: str, pco: PCO = Depends(get_pco)) -> list:
     """
-    Get information for a particular song from the Planning Center Online API.
+    Find songs by title.
 
-    Args: 
-        song_id (str): The ID for the song. 
-        arrangement_id (str): The ID for the arrangement within a song. 
+    Args:
+        title (str): The title of the song to search for.
+
+    Returns:
+        list: List of songs matching the title.
     """
-    response = pco.get(f'/services/v2/songs/{song_id}/arrangements/{arrangement_id}')
+    response = await asyncio.to_thread(pco.get, f'/services/v2/songs?where[title]={title}&where[hidden]=false')
     return response['data']
 
 @mcp.tool()
-def get_keys_for_arrangement_of_song(song_id: str, arrangement_id: str) -> list:
-    """
-    Get a list of keys available for a particular song ID and arrangement ID from the Planning Center Online API. 
-
-    Args: 
-        song_id (str): The ID for the song. 
-        arrangement_id (str): The ID for the arrangement within a song. 
-    """
-    response = pco.get(f'/services/v2/songs/{song_id}/arrangements{arrangement_id}/keys')
-    return response['data']
-
-@mcp.tool()
-def create_song(title: str, ccli: str = None) -> dict:
+async def create_song(title: str, ccli: str = None, pco: PCO = Depends(get_pco)) -> dict:
     """
     Create a new song in Planning Center Online.
 
@@ -134,37 +730,51 @@ def create_song(title: str, ccli: str = None) -> dict:
         attributes["ccli_number"] = ccli
 
     body = pco.template('Song', attributes)
-    response = pco.post('/services/v2/songs', body)
+    response = await asyncio.to_thread(pco.post, '/services/v2/songs', body)
     return response['data']
 
 @mcp.tool()
-def find_song_by_title(title: str) -> list:
+async def get_all_arrangements_for_song(song_id: str, pco: PCO = Depends(get_pco)) -> list:
     """
-    Find songs by title.
+    Get a list of all the arrangements for a particular song from the Planning Center Online API.
 
     Args:
-        title (str): The title of the song to search for.
-
-    Returns:
-        list: List of songs matching the title.
+        song_id (str): The ID for the song.
     """
-    response = pco.get(f'/services/v2/songs?where[title]={title}&where[hidden]=false')
+    response = await asyncio.to_thread(pco.get, f'/services/v2/songs/{song_id}/arrangements')
     return response['data']
 
 @mcp.tool()
-def get_song(song_id: str) -> dict:
+async def get_arrangement_for_song(song_id: str, arrangement_id: str, pco: PCO = Depends(get_pco)) -> list:
     """
-    Fetch details for a specific song.
+    Get information for a particular song from the Planning Center Online API.
 
     Args:
-        song_id (str): The ID of the song.
+        song_id (str): The ID for the song.
+        arrangement_id (str): The ID for the arrangement within a song.
     """
-    # Using the direct get method as shown in the documentation
-    response = pco.get(f'/services/v2/songs/{song_id}')
+    response = await asyncio.to_thread(pco.get, f'/services/v2/songs/{song_id}/arrangements/{arrangement_id}')
     return response['data']
 
 @mcp.tool()
-def assign_tags_to_song(song_id: str, tag_names: list[str]) -> dict:
+async def get_keys_for_arrangement_of_song(song_id: str, arrangement_id: str, pco: PCO = Depends(get_pco)) -> list:
+    """
+    Get a list of keys available for a particular song ID and arrangement ID from the Planning Center Online API.
+
+    Args:
+        song_id (str): The ID for the song.
+        arrangement_id (str): The ID for the arrangement within a song.
+    """
+    response = await asyncio.to_thread(pco.get, f'/services/v2/songs/{song_id}/arrangements/{arrangement_id}/keys')
+    return response['data']
+
+
+# =============================================================================
+# Tag Operations
+# =============================================================================
+
+@mcp.tool()
+async def assign_tags_to_song(song_id: str, tag_names: list[str], pco: PCO = Depends(get_pco)) -> dict:
     """
     Assign tags to a specific song.
 
@@ -175,13 +785,10 @@ def assign_tags_to_song(song_id: str, tag_names: list[str]) -> dict:
     Returns:
         dict: Success status and message.
     """
-    # Get all tag groups with their tags included
-    tag_groups_response = pco.get('/services/v2/tag_groups?include=tags&filter=song')
+    tag_groups_response = await asyncio.to_thread(pco.get, '/services/v2/tag_groups?include=tags&filter=song')
 
-    # Extract tags from the included section
     included_tags = tag_groups_response.get('included', [])
 
-    # Find the tag IDs for the requested tag names
     tag_data = []
     for tag_name in tag_names:
         for tag in included_tags:
@@ -195,7 +802,6 @@ def assign_tags_to_song(song_id: str, tag_names: list[str]) -> dict:
     if not tag_data:
         return {"success": False, "message": "No matching tags found"}
 
-    # Build the request body
     body = {
         "data": {
             "type": "TagAssignment",
@@ -208,27 +814,22 @@ def assign_tags_to_song(song_id: str, tag_names: list[str]) -> dict:
         }
     }
 
-    # Make the POST request
-    response = pco.post(f'/services/v2/songs/{song_id}/assign_tags', body)
+    await asyncio.to_thread(pco.post, f'/services/v2/songs/{song_id}/assign_tags', body)
 
-    # A 204 status means success with no content
     return {"success": True, "message": f"Successfully assigned {len(tag_data)} tag(s) to song {song_id}"}
 
 @mcp.tool()
-def find_songs_by_tags(tag_names: list[str]) -> list:
+async def find_songs_by_tags(tag_names: list[str], pco: PCO = Depends(get_pco)) -> list:
     """
     Find songs that have all of the specified tags.
 
     Args:
         tag_names (list[str]): List of tag names to filter songs by. Songs must have all specified tags.
     """
-    # Get all tag groups with their tags included
-    tag_groups_response = pco.get('/services/v2/tag_groups?include=tags&filter=song')
+    tag_groups_response = await asyncio.to_thread(pco.get, '/services/v2/tag_groups?include=tags&filter=song')
 
-    # Extract tags from the included section
     included_tags = tag_groups_response.get('included', [])
 
-    # Find the tag IDs for the requested tag names
     tag_ids = []
     for tag_name in tag_names:
         for tag in included_tags:
@@ -239,69 +840,12 @@ def find_songs_by_tags(tag_names: list[str]) -> list:
     if not tag_ids:
         return []
 
-    # Build the query string with tag filters
-    # Multiple tag filters create an AND condition
     tag_filters = '&'.join([f'where[song_tag_ids]={tag_id}' for tag_id in tag_ids])
     query = f'/services/v2/songs?per_page=200&where[hidden]=false&{tag_filters}'
 
-    response = pco.get(query)
+    response = await asyncio.to_thread(pco.get, query)
     return response['data']
 
 
-
 if __name__ == "__main__":
-    # Example usage of the tools
-    print("PCO Services MCP Server - CLI Test Mode")
-    
-    # Test getting service types
-    print("\nFetching service types...")
-    service_types = get_service_types()
-    print(f"Found {len(service_types)} service types")
-    print(service_types)
-    
-    if service_types:
-        # Test getting plans for the first service type
-        service_type_id = service_types[0].get('id')
-        print(f"\nFetching plans for service type ID: {service_type_id}")
-        plans = get_plans(service_type_id)
-        print(f"Found {len(plans)} plans")
-        
-        if plans:
-            # Test getting plan items for the first plan
-            plan_id = plans[0].get('id')
-            print(f"\nFetching items for plan ID: {plan_id}")
-            items = get_plan_items(plan_id)
-            print(f"Found {len(items)} items")
-            
-            # Test getting team members for the first plan
-            print(f"\nFetching team members for plan ID: {plan_id}")
-            team_members = get_plan_team_members(plan_id)
-            print(f"Found {len(team_members)} team members")
-            
-            if team_members:
-                # Test getting assignments for the first team member
-                team_member_id = team_members[0].get('id')
-                print(f"\nFetching assignments for team member ID: {team_member_id}")
-                # assignments = get_plan_team_member_assignments(plan_id, team_member_id)
-                # print(f"Found {len(assignments)} assignments")
-    
-    # Test getting songs
-    print("\nFetching songs...")
-    songs = get_songs()
-    print(f"Found {len(songs)} songs")
-    
-    if songs:
-        # Test getting details for the first song
-        song_id = songs[0].get('id')
-        print(f"\nFetching details for song ID: {song_id}")
-        song_details = get_song(song_id)
-        print(f"Song details: {song_details.get('title')} by {song_details.get('author')}")
-    
-    # # Test iterating through plans
-    # if service_types:
-    #     service_type_id = service_types[0].get('id')
-    #     print(f"\nIterating through plans for service type ID: {service_type_id}")
-    #     plans = iterate_through_plans(service_type_id)
-    #     print(f"Found {len(plans)} plans through iteration")
-    
-    print("\nCLI test completed.")
+    mcp.run(transport="http", host="0.0.0.0", port=8000)


### PR DESCRIPTION
Convert from single-user STDIO server with PAT auth to a shared HTTP server with per-user OAuth via FastMCP's OAuthProxy. Add full CRUD operations for service types, plans, plan times, plan items, and team members. Add schedule management (view/accept/decline). All tools are now async with per-user PCO clients via dependency injection.